### PR TITLE
Setting EdgeFunctions revisionId to omitempty

### DIFF
--- a/edgefunctions/edgefunctions.go
+++ b/edgefunctions/edgefunctions.go
@@ -17,7 +17,7 @@ type EdgeFunction struct {
 	Sha256               string                `json:"sha256,omitempty"`
 	EnvironmentVariables []EnvironmentVariable `json:"environmentVariables"`
 	ReservedConcurrency  int                   `json:"reservedConcurrency,omitempty"`
-	RevisionID           int                   `json:"revisionId"`
+	RevisionID           int                   `json:"revisionId,omitempty"`
 	Version              int                   `json:"version,omitempty"`
 }
 


### PR DESCRIPTION
This prevents a failure when '0' is sent as the `revisionId` on function update requests due to the variable being unset, and as such not equal to the current live revision.